### PR TITLE
bugfix/accurics_remediation_1674745205431929 - Auto Generated Pull Request From Accurics

### DIFF
--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -27,7 +27,7 @@ resource "aws_iam_role" "km_ecs_task_execution_role" {
 EOF
 
   tags = merge(var.default_tags, {
-    name        = "km_ecs_task_execution_role_${var.environment}"
+    name = "km_ecs_task_execution_role_${var.environment}"
   })
 }
 
@@ -106,7 +106,7 @@ resource "aws_ecs_service" "km_ecs_service" {
   network_configuration {
     assign_public_ip = true
     subnets          = var.private_subnet
-    security_groups  = [ var.elb_sg ]
+    security_groups  = [var.elb_sg]
   }
   tags = merge(var.default_tags, {
   })
@@ -121,12 +121,17 @@ resource "aws_cloudwatch_log_group" "km_log_group" {
   })
 }
 
-resource "aws_instance" "km_vm"{
-  ami = data.aws_ami.ubuntu_ami.id
-  instance_type = "t2.micro"
-  vpc_security_group_ids = [ var.elb_sg ]
-  subnet_id = var.public_subnet[0]
+resource "aws_instance" "km_vm" {
+  ami                    = data.aws_ami.ubuntu_ami.id
+  instance_type          = "t2.micro"
+  vpc_security_group_ids = [var.elb_sg]
+  subnet_id              = var.public_subnet[0]
   tags = merge(var.default_tags, {
     Name = "km_vm_${var.environment}"
   })
+
+  metadata_options {
+    http_endpoint = "disabled"
+    http_tokens   = "required"
+  }
 }


### PR DESCRIPTION
IMDv1 is vulnerable to SSRF attack. Thus, EC2 Instance should have metadata_options block with either http_endpoint attribute set to disabled or ensure http_tokens attribute is set to required. This ensures IMDv2 is being used.